### PR TITLE
Add support for new JCB bin ranges effective from April 2022

### DIFF
--- a/lib/active_merchant/billing/credit_card_methods.rb
+++ b/lib/active_merchant/billing/credit_card_methods.rb
@@ -11,7 +11,7 @@ module ActiveMerchant #:nodoc:
         'american_express'   => ->(num) { num =~ /^3[47]\d{13}$/ },
         'naranja'            => ->(num) { num&.size == 16 && in_bin_range?(num.slice(0, 6), NARANJA_RANGES) },
         'diners_club'        => ->(num) { num =~ /^3(0[0-5]|[68]\d)\d{11,16}$/ },
-        'jcb'                => ->(num) { num =~ /^35(28|29|[3-8]\d)\d{12}$/ },
+        'jcb'                => ->(num) { num&.size == 16 && in_bin_range?(num.slice(0, 8), JCB_RANGES) },
         'dankort'            => ->(num) { num =~ /^5019\d{12}$/ },
         'maestro'            => lambda { |num|
           (12..19).cover?(num&.size) && (
@@ -70,6 +70,15 @@ module ActiveMerchant #:nodoc:
       MASTERCARD_RANGES = [
         (222100..272099),
         (510000..559999),
+      ]
+
+      JCB_RANGES = [
+        (35280000..35899999),
+        (30880000..30949999),
+        (30960000..31029999),
+        (31120000..31209999),
+        (31580000..31599999),
+        (33370000..33499999)
       ]
 
       MAESTRO_BINS = Set.new(

--- a/test/unit/credit_card_methods_test.rb
+++ b/test/unit/credit_card_methods_test.rb
@@ -127,6 +127,44 @@ class CreditCardMethodsTest < Test::Unit::TestCase
     assert_equal 'diners_club', CreditCard.brand?('30401000000000')
   end
 
+  def test_should_detect_jcb_cards
+    # 35280000 - 35899999
+    assert_not_equal 'jcb', CreditCard.brand?('3527999900000000')
+    assert_equal 'jcb', CreditCard.brand?('3528000000000000')
+    assert_equal 'jcb', CreditCard.brand?('3589999999999999')
+    assert_not_equal 'jcb', CreditCard.brand?('3590000000000000')
+
+    # 30880000 - 30949999
+    assert_not_equal 'jcb', CreditCard.brand?('3087999900000000')
+    assert_equal 'jcb', CreditCard.brand?('3088000000000000')
+    assert_equal 'jcb', CreditCard.brand?('3094999999999999')
+    assert_not_equal 'jcb', CreditCard.brand?('3095000000000000')
+
+    # 30960000 - 3102999999999999
+    assert_not_equal 'jcb', CreditCard.brand?('3095999900000000')
+    assert_equal 'jcb', CreditCard.brand?('3096000000000000')
+    assert_equal 'jcb', CreditCard.brand?('3102999999999999')
+    assert_not_equal 'jcb', CreditCard.brand?('3103000000000000')
+
+    # 31120000 - 31209999
+    assert_not_equal 'jcb', CreditCard.brand?('3111999900000000')
+    assert_equal 'jcb', CreditCard.brand?('3112000000000000')
+    assert_equal 'jcb', CreditCard.brand?('3120999999999999')
+    assert_not_equal 'jcb', CreditCard.brand?('3121000000000000')
+
+    # 31580000 - 31599999
+    assert_not_equal 'jcb', CreditCard.brand?('3157999900000000')
+    assert_equal 'jcb', CreditCard.brand?('3158000000000000')
+    assert_equal 'jcb', CreditCard.brand?('3159999999999999')
+    assert_not_equal 'jcb', CreditCard.brand?('3160000000000000')
+
+    # 33370000 - 33499999
+    assert_not_equal 'jcb', CreditCard.brand?('3336999900000000')
+    assert_equal 'jcb', CreditCard.brand?('3337000000000000')
+    assert_equal 'jcb', CreditCard.brand?('3349999999999999')
+    assert_not_equal 'jcb', CreditCard.brand?('3350000000000000')
+  end
+
   def test_should_detect_maestro_dk_as_maestro
     assert_equal 'maestro', CreditCard.brand?('6769271000000000')
   end


### PR DESCRIPTION
### Description
From April 2022, JCB will update their IIN from 6 digits to 8, along with this the following BIN ranges will be associated:

#### JCB BIN ranges
| Min | Max | Comment |
|-|-|-|
| 35280000 | 35899999 | Existing |
|30880000 | 30949999 | New from April 2022 |
| 30960000 | 31029999 | New from April 2022 |
| 31120000 | 31209999 | New from April 2022 |
| 31580000 | 31599999 | New from April 2022 |
| 33370000 | 33499999 | New from April 2022|

### Refs
* [Trello card](https://trello.com/c/tKEq5I5r/2389-3-gateway-support-new-jcb-bins-3)
* [ActiveMerchant PR](https://github.com/activemerchant/active_merchant/pull/4032)